### PR TITLE
Explicitly manage FIFO thread resource

### DIFF
--- a/src/plwm.pl
+++ b/src/plwm.pl
@@ -2341,11 +2341,13 @@ main() :-
 	update_free_win_space,
 	update_ws_atoms,
 
-	fifo:setup_fifo,
+	fifo:setup_fifo(FifoThread),
 
 	setup_hooks,
 	run_hook(start),
 
-	eventloop
+	eventloop,
+	thread_send_message(FifoThread, shutdown),
+	thread_join(FifoThread)
 .
 


### PR DESCRIPTION
Test "setup_fifo + (already exists)" would sometimes error with ENOENT
on `/tmp/test-fifo`. We noticed that it was intermittent and nailed it
down to a race condition between "setup_fifo +" and "setup_fifo +
(already exists)" both racing to create and delete `/tmp/test-fifo`.

Previously, we were creating the FIFO thread in a detached state,
which made verification and management challenging. Tests were spawning
multiple copies of the thread, forcing workarounds and the issue above.

This commit introduces explicit management for the FIFO thread, which
allows us to be more direct and precise in the previously-failing tests.